### PR TITLE
`Project.toml`: Loosen the `[compat]` entry for LinearAlgebra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 FFTW = "1.10.0"
-LinearAlgebra = "1.12.0"
+LinearAlgebra = "1"
 PrecompileTools = "1.3.3"
 SpecialFunctions = "2.6.1"
 StaticArrays = "1.9.16"


### PR DESCRIPTION
This package supports Julia 1.10+. However, the existing `[compat]` entry for LinearAlgebra is `LinearAlgebra = "1.12.0"`, which prevents the package from being loaded on Julia 1.10.

This PR loosens the `[compat]` entry, to allow the package to be loaded on Julia 1.10.